### PR TITLE
Add krusthol's solution for RGB to Hexadecimal

### DIFF
--- a/chall02/krusthol.c
+++ b/chall02/krusthol.c
@@ -1,0 +1,51 @@
+#include <stdlib.h>
+
+void	double_hex_color(char *hex, char *rgb_hex_value, int value, int loc)
+{
+	rgb_hex_value[loc] = hex[value % 16];
+	rgb_hex_value[loc + 1] = hex[(value /= 16) % 16];
+}
+
+void	single_hex_color(char *hex, char *rgb_hex_value, int value, int loc)
+{
+	rgb_hex_value[loc] = '0';
+	rgb_hex_value[loc + 1] = hex[value];
+}
+
+char	*error_range(char *rgb_hex_value)
+{
+	rgb_hex_value[1] = 'e';
+	rgb_hex_value[2] = 'r';
+	rgb_hex_value[3] = 'r';
+	rgb_hex_value[4] = 'o';
+	rgb_hex_value[5] = 'r';
+	rgb_hex_value[6] = '!';
+	return (rgb_hex_value);
+}
+
+char	*hv_rgb2hex(int r, int g, int b)
+{
+	char hex[16] = { "0123456789abcdef" };
+	char *rgb_hex_value;
+
+	if (!(rgb_hex_value = (char *)malloc(sizeof(char) * 8)))
+		return (NULL);
+	rgb_hex_value[0] = '#';
+	rgb_hex_value[7] = '\0';
+	if ((r > 255 || g > 255 || b > 255)
+		|| (r < 0 || g < 0 || b < 0))
+		return (error_range(rgb_hex_value));
+	if (r > 15)
+		double_hex_color(hex, rgb_hex_value, r, 1);
+	else
+		single_hex_color(hex, rgb_hex_value, r, 1);
+	if (g > 15)
+		double_hex_color(hex, rgb_hex_value, g, 3);
+	else
+		single_hex_color(hex, rgb_hex_value, g, 3);
+	if (b > 15)
+		double_hex_color(hex, rgb_hex_value, b, 5);
+	else
+		single_hex_color(hex, rgb_hex_value, b, 5);
+	return (rgb_hex_value);
+}

--- a/chall02/krusthol.c
+++ b/chall02/krusthol.c
@@ -1,51 +1,43 @@
 #include <stdlib.h>
 
-void	double_hex_color(char *hex, char *rgb_hex_value, int value, int loc)
+static void	convert_hex(char *hex_table, char *hex_value, int value, int loc)
 {
-	rgb_hex_value[loc] = hex[value % 16];
-	rgb_hex_value[loc + 1] = hex[(value /= 16) % 16];
+	if (value > 15)
+	{
+		hex_value[loc + 1] = hex_table[value % 16];
+		hex_value[loc] = hex_table[(value /= 16)];
+	}
+	else
+	{
+		hex_value[loc] = '0';
+		hex_value[loc + 1] = hex_table[value];
+	}
 }
 
-void	single_hex_color(char *hex, char *rgb_hex_value, int value, int loc)
+static char	*error_range(char *hex_value)
 {
-	rgb_hex_value[loc] = '0';
-	rgb_hex_value[loc + 1] = hex[value];
+	hex_value[1] = 'e';
+	hex_value[2] = 'r';
+	hex_value[3] = 'r';
+	hex_value[4] = 'o';
+	hex_value[5] = 'r';
+	hex_value[6] = '!';
+	return (hex_value);
 }
 
-char	*error_range(char *rgb_hex_value)
+char		*hv_rgb2hex(int r, int g, int b)
 {
-	rgb_hex_value[1] = 'e';
-	rgb_hex_value[2] = 'r';
-	rgb_hex_value[3] = 'r';
-	rgb_hex_value[4] = 'o';
-	rgb_hex_value[5] = 'r';
-	rgb_hex_value[6] = '!';
-	return (rgb_hex_value);
-}
+	char	hex_table[16] = { "0123456789abcdef" };
+	char	*hex_value;
 
-char	*hv_rgb2hex(int r, int g, int b)
-{
-	char hex[16] = { "0123456789abcdef" };
-	char *rgb_hex_value;
-
-	if (!(rgb_hex_value = (char *)malloc(sizeof(char) * 8)))
+	if (!(hex_value = (char *)malloc(sizeof(char) * 8)))
 		return (NULL);
-	rgb_hex_value[0] = '#';
-	rgb_hex_value[7] = '\0';
-	if ((r > 255 || g > 255 || b > 255)
-		|| (r < 0 || g < 0 || b < 0))
-		return (error_range(rgb_hex_value));
-	if (r > 15)
-		double_hex_color(hex, rgb_hex_value, r, 1);
-	else
-		single_hex_color(hex, rgb_hex_value, r, 1);
-	if (g > 15)
-		double_hex_color(hex, rgb_hex_value, g, 3);
-	else
-		single_hex_color(hex, rgb_hex_value, g, 3);
-	if (b > 15)
-		double_hex_color(hex, rgb_hex_value, b, 5);
-	else
-		single_hex_color(hex, rgb_hex_value, b, 5);
-	return (rgb_hex_value);
+	hex_value[0] = '#';
+	hex_value[7] = '\0';
+	if ((r > 255 || g > 255 || b > 255) || (r < 0 || g < 0 || b < 0))
+		return (error_range(hex_value));
+	convert_hex(hex_table, hex_value, r, 1);
+	convert_hex(hex_table, hex_value, g, 3);
+	convert_hex(hex_table, hex_value, b, 5);
+	return (hex_value);
 }


### PR DESCRIPTION
Approach:
Since I have done similar things, I just combined some previous approaches I've used in the C Exams for hex conversion with the RGB value things I've coded in the graphics branch, added an error behaviour which was not asked for, but which I felt useful to implement anyway. Only one thing in code that bypasses Norm, the hex value map instanciation at declaration, and not including header by convention.

Code:
Simple hex conversion by modulo from Hex string table, formatting three color portions RGB, returning "#error!" string if out of range 0-255 for any of the RGB values. Mallocing the return string with malloc from stdlib.h, assuming memory management will be handled by the outer program.