### PR TITLE
Chall02 Solution

### DIFF
--- a/chall02/tdawson.c
+++ b/chall02/tdawson.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <unistd.h>
+
+char *hv_rgb2hex(int r, int g, int b)
+{
+	char *hex_str;
+
+	if (r < 0 || g < 0 || b < 0)
+		return NULL;
+
+	hex_str = malloc(8);
+	unsigned int hex = ((r & 0xff) << 16) + ((g & 0xff) << 8) + (b & 0xff);
+	sprintf(hex_str, "#%x", hex);
+	return hex_str;
+}

--- a/chall02/tdawson.c
+++ b/chall02/tdawson.c
@@ -7,7 +7,6 @@ char *hv_rgb2hex(int r, int g, int b)
 
 	if (r < 0 || g < 0 || b < 0)
 		return NULL;
-
 	hex_str = malloc(8);
 	unsigned int hex = ((r & 0xff) << 16) + ((g & 0xff) << 8) + (b & 0xff);
 	sprintf(hex_str, "#%x", hex);

--- a/chall02/tdawson.c
+++ b/chall02/tdawson.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <unistd.h>
+#include <stdlib.h>
 
 char *hv_rgb2hex(int r, int g, int b)
 {
@@ -9,6 +9,6 @@ char *hv_rgb2hex(int r, int g, int b)
 		return NULL;
 	hex_str = malloc(8);
 	unsigned int hex = ((r & 0xff) << 16) + ((g & 0xff) << 8) + (b & 0xff);
-	sprintf(hex_str, "#%x", hex);
+	sprintf(hex_str, "#%06x", hex);
 	return hex_str;
 }

--- a/chall02/tdawson.c
+++ b/chall02/tdawson.c
@@ -5,9 +5,8 @@ char *hv_rgb2hex(int r, int g, int b)
 {
 	char *hex_str;
 
-	if (r < 0 || g < 0 || b < 0)
+	if (!(hex_str = malloc(8)))
 		return NULL;
-	hex_str = malloc(8);
 	unsigned int hex = ((r & 0xff) << 16) + ((g & 0xff) << 8) + (b & 0xff);
 	sprintf(hex_str, "#%06x", hex);
 	return hex_str;


### PR DESCRIPTION
I use bitmasking with the bitwise AND operator and the value 0xff (255) to discard bits from the integer values so that r, g and b are all between 0-255, and then use bitshifting to move the bits to the correct position. Since the bitmask ensures rgb channel values are between 0-255 I do not check for input outside of that range since the subject doesn't specify required behaviour in such cases. Finally we format the hex value as a string starting with a '#' using sprintf.
