### PR TITLE
chall03 submit

### DIFF
--- a/chall03/srouhe.go
+++ b/chall03/srouhe.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"net/http"
+	"io/ioutil"
+)
+
+
+func errCheck(err error) {
+	if err != nil {
+        log.Fatalf("Fatal error: %v", err)
+    }
+}
+
+func parseResp(respBody string) (string) {
+
+	re, err := regexp.Compile("id=(\\d*).*r=(\\d{1,3}).*g=(\\d{1,3}).*b=(\\d{1,3})")
+	errCheck(err)
+	matches := re.FindAllStringSubmatch(respBody, -1)
+	r, err := strconv.Atoi(matches[0][2])
+	errCheck(err)
+	g, err := strconv.Atoi(matches[0][3])
+	errCheck(err)
+	b, err := strconv.Atoi(matches[0][4])
+	errCheck(err)
+	return (fmt.Sprintf("https://chall03.hive.fi/?id=%v&resp=%.2x%.2x%.2x", matches[0][1], r, g, b))
+}
+
+func main() {
+	resp, err := http.Get("https://chall03.hive.fi/")
+	defer resp.Body.Close()
+	errCheck(err)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	errCheck(err)
+
+	response, err := http.Get(parseResp(string(body)))
+	defer response.Body.Close()
+	errCheck(err)
+	log.Printf("Response status code: [%v]\n", response.StatusCode)
+}


### PR DESCRIPTION
Everywhere we use errCheck utility to handle errors. In case of errors we use Fatalf to print out the error and exit afterwards. Also both resp bodies are deferred to close when the program exits.

1. Get request to the initial URL
2. Read bytes from http response body and send it to parseResp()
3. Match the wanted values with regex FindAllStringSubmatch (id, r, g, b)
4. Convert rgb values with Atoi to int
5. Use Sprintf to format the second get request (id as is, r, g and b values to hex string with 2 width)
6. Log the status code from the second request